### PR TITLE
Max zoom clusters still spiderfy

### DIFF
--- a/inst/htmlwidgets/lib/map/cluster-utils.js
+++ b/inst/htmlwidgets/lib/map/cluster-utils.js
@@ -40,7 +40,7 @@ function addClusterLayer(el, layerId, sourceId) {
     layerId
   );
 
-  // 3. Add a symbol layer for cluster counts
+  // Add a symbol layer for cluster counts
   el.mapInstance.addLayer(
     {
       id: `${layerId}-cluster-count`,
@@ -84,7 +84,9 @@ function addClusterSpiderfying(el, layerId, sourceId) {
     layerId,
   ];
   el.mapInstance.on('click', async (e) => {
-    const features = el.mapInstance.queryRenderedFeatures(e.point, { layers: spiderfyLayers });
+    const features = el.mapInstance.queryRenderedFeatures(e.point, {
+      layers: spiderfyLayers,
+    });
     if (features.length === 0) {
       // Click was NOT on any of the spiderfyLayers - close any open spiderfy
       closeSpiderfy(el.mapInstance);
@@ -299,7 +301,12 @@ function toggleLayerClustering(map, layerId, enable) {
   const layer = map.getLayer(layerId);
   if (layer) {
     const sourceId = layer.source; // Assuming layerId is the source ID
-    map.getSource(sourceId).setClusterOptions({ cluster: enable });
+    map.getSource(sourceId).setClusterOptions({
+      cluster: enable,
+      clusterRadius: enable ? 30 : 50, // Smaller radius for less aggressive clustering
+      clusterMaxZoom: 24, // Always allow clustering at all zoom levels to handle overlapping points
+      clusterMinPoints: enable ? 2 : null, // Minimum points required to form a cluster
+    });
 
     if (enable) {
       addFilterToLayer(map, layerId, ['!', ['has', 'point_count']]);

--- a/inst/htmlwidgets/lib/map/layer-utils.js
+++ b/inst/htmlwidgets/lib/map/layer-utils.js
@@ -43,9 +43,7 @@ function initiateTiles(el, mapParams) {
   el.mapInstance.addLayer({
     id: 'background-blue',
     type: 'background',
-    paint: {
-      'background-color': fallbackColour,
-    },
+    paint: { 'background-color': fallbackColour },
   });
   const loadedTileIds = getTileIds(loadedTiles);
   // First add all the tiles that are needed
@@ -128,10 +126,30 @@ function addLayerToMap(el, layer) {
     layerObj.filter = layer.filter; // Add filter if specified
   }
 
+  let sourceId;
   if (typeof layer.source === 'object' && layer.source.type === 'geojson') {
-    layerObj.source.generateId = true;
+    // Create unique source ID for inline GeoJSON sources
+    sourceId = `source-${layer.id}`;
+
+    // Always enable clustering for GeoJSON sources to handle overlapping coordinates
+    const sourceOptions = {
+      ...layer.source,
+      generateId: true,
+      cluster: true,
+      // If can_cluster=false, use very restrictive settings to only cluster identical coordinates
+      clusterRadius: layer.canCluster ? 50 : 0, // 0 radius = only exact same coords cluster
+      clusterMaxZoom: 24, // Always allow clustering at all zoom levels to handle overlaps
+      clusterMinPoints: 2, // Always require at least 2 points to form a cluster
+    };
+
+    // Add the source to the map
+    map.addSource(sourceId, sourceOptions);
+
+    // Update layerObj to reference the source ID
+    layerObj.source = sourceId;
   } else if (typeof layer.source === 'string') {
-    // Handle string source if needed
+    // Handle string source ID reference
+    sourceId = layer.source;
     layerObj.source = layer.source;
   }
   map.addLayer(layerObj, 'spiderfy-lines');
@@ -144,8 +162,12 @@ function addLayerToMap(el, layer) {
     addLayerHover(map, layerObj.id, layer.hoverColumn);
   }
 
-  if (layer.canCluster) {
-    addClusterLayer(el, layerObj.id, layer.source);
+  // Always add cluster layers for GeoJSON sources to handle overlapping coordinates
+  if (typeof layer.source === 'object' && layer.source.type === 'geojson') {
+    addClusterLayer(el, layerObj.id, sourceId);
+  } else if (layer.canCluster) {
+    // For string source references, only add clustering if explicitly requested
+    addClusterLayer(el, layerObj.id, sourceId);
   }
 
   // if (layer.onFeatureClick) {


### PR DESCRIPTION
Making sure clusters still appear at max zoom if there are pins at the same location (for spiderfying pins with the same coords)