### PR TITLE
Adding the ability to sort spiderfied cluster points by a column value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.toml
 inst/examples/app.R
+inst/examples/www
 
 renv
 .Rprofile
@@ -13,3 +14,5 @@ renv
 inst/doc
 /doc/
 /Meta/
+
+.Renviron

--- a/inst/htmlwidgets/lib/map/cluster-utils.js
+++ b/inst/htmlwidgets/lib/map/cluster-utils.js
@@ -162,8 +162,7 @@ function addClusterSpiderfying(el, layerId, sourceId, popupColumn, clusterOption
     });
     if (features.length === 0) {
       // Click was NOT on any of the spiderfyLayers - close any open spiderfy
-      closeSpiderfy(el.mapInstance);
-      el.openClusterId = null;
+      closeSpiderfy(el);
     }
   });
   el.mapInstance.on('click', `${layerId}-clusters`, (e) => {
@@ -173,8 +172,7 @@ function addClusterSpiderfying(el, layerId, sourceId, popupColumn, clusterOption
   // When a zoom is started, close any open spiderfy
   el.mapInstance.on('zoomstart', function () {
     if (el.openClusterId) {
-      closeSpiderfy(el.mapInstance); // Close any open cluster when zooming starts
-      el.openClusterId = null; // Reset the open cluster ID
+      closeSpiderfy(el); // Close any open cluster when zooming starts
     }
   });
 
@@ -223,20 +221,37 @@ function addSpiderfyingLayers(el) {
  * @param {object} map MapLibre map instance.
  * @param {object[]} features Cluster features to spiderfy.
  * @param {number[]} centerLngLat Cluster center coordinates as [lng, lat].
- * @param {number} [baseRadiusPx=50] Initial radius in pixels for the spiderfy circles.
- * @param {number} [spacing=40] Distance in pixels between points in the spiral.
- * @param {number} [maxCircleCount=10] Max number of points to have in a circle before switching
- *   to a spiral pattern.
+ * @param {object} [options={}] Optional spiderfy options to configure spiderfying behavior.
+ * @param {string} [options.orderKey] Optional property key to order the features by before
+ *   spiderfying.
+ * @param {string} [options.orderDirection='asc'] Optional order direction ('asc' or 'desc') for
+ *   ordering features.
+ * @param {number} [options.baseRadiusPx=50] Initial radius in pixels for the spiderfy circles.
+ * @param {number} [options.spacing=40] Distance in pixels between points in the spiral.
+ * @param {number} [options.maxCircleCount=10] Max number of points to have in a circle before
+ *   switching to a spiral pattern.
  * @returns {object[]} Cluster features with updated coordinates for spiderfying.
  */
-function getSpiderfiedFeatures(
-  map,
-  features,
-  centerLngLat,
-  baseRadiusPx = 50,
-  spacing = 40,
-  maxCircleCount = 10,
-) {
+function getSpiderfiedFeatures(map, features, centerLngLat, options = {}) {
+  const {
+    baseRadiusPx = 50,
+    spacing = 40,
+    maxCircleCount = 10,
+    orderKey,
+    orderDirection = 'asc',
+  } = options;
+  if (orderKey) {
+    features = features?.sort((a, b) => {
+      const aOrderVal = a.properties?.[orderKey];
+      const bOrderVal = b.properties?.[orderKey];
+      const beforeVal = orderDirection === 'asc' ? -1 : 1;
+      const afterVal = orderDirection === 'asc' ? 1 : -1;
+      if (aOrderVal == null) return 1;
+      if (bOrderVal == null) return -1;
+
+      return aOrderVal < bOrderVal ? beforeVal : aOrderVal > bOrderVal ? afterVal : 0; // Sort both number or strings
+    });
+  }
   const center = map.project(centerLngLat);
   const result = [];
   const total = features.length;
@@ -320,7 +335,7 @@ function getSpiderfyLines(center, features) {
  */
 async function onClusterClick(e, el, layerId, sourceId, clusterOptions) {
   const spiderfyOptions = clusterOptions?.spiderfyOptions || {};
-  closeSpiderfy(el.mapInstance); // Close any open cluster before opening a new one
+  closeSpiderfy(el); // Close any open cluster before opening a new one
 
   // Get the cluster that was clicked
   const features = el.mapInstance.queryRenderedFeatures(e.point, {
@@ -352,6 +367,10 @@ async function onClusterClick(e, el, layerId, sourceId, clusterOptions) {
       el.mapInstance,
       clusterFeatures,
       clusterCoords,
+      {
+        orderKey: clusterOptions.orderKey || el.clusterOptions.orderKey,
+        orderDirection: clusterOptions.orderDirection || el.clusterOptions.orderDirection,
+      },
     );
     // Get the lines between the spiderfied points
     const spiderfyLines = getSpiderfyLines(clusterCoords, spiderfiedFeatures);
@@ -450,10 +469,16 @@ function toggleLayerClustering(map, layerId, enable) {
 /**
  * Clear the spiderfy layer data to close any open spiderfy clusters.
  *
- * @param {object} map MapLibre map instance.
+ * @param {object} el toro element instance.
  * @returns {void}
  */
-function closeSpiderfy(map) {
+function closeSpiderfy(el) {
+  const map = el.mapInstance;
+  // Hide any open spiderfy popup
+  if (map._popup) {
+    map._popup.remove();
+    map._popup = null;
+  }
   map.getSource('spiderfy-pins-source').setData({
     type: 'FeatureCollection',
     features: [],
@@ -462,9 +487,5 @@ function closeSpiderfy(map) {
     type: 'FeatureCollection',
     features: [],
   });
-  // Hide any open spiderfy popup
-  if (map._popup) {
-    map._popup.remove();
-    map._popup = null;
-  }
+  el.openClusterId = null;
 }

--- a/inst/htmlwidgets/lib/map/controls/paint-controls.js
+++ b/inst/htmlwidgets/lib/map/controls/paint-controls.js
@@ -1,6 +1,7 @@
 class PaintControl {
-  constructor(widgetInstance, options) {
-    this._widgetInstance = widgetInstance;
+  constructor(el, options) {
+    this._el = el;
+    this._widgetInstance = el.widgetInstance;
     this._options = options;
     this._inputElId = this._options.id;
 
@@ -135,6 +136,8 @@ class PaintControl {
   }
 
   _updateSelectedOption(inputValue) {
+    // If the target layer has a cluster open (spiderfying), close it first
+    closeSpiderfy(this._el);
     // Find the selected paint option based on the input value
     let selectedOption = this._options.optionsList.find(
       (option) => option.value === inputValue || option.id === inputValue,
@@ -182,14 +185,15 @@ class PaintControl {
 
 function addPaintControl(el, options) {
   // Enforce unique paint control IDs by replacing an existing control with the same ID.
-  removePaintControl(el.widgetInstance, options.id);
+  removePaintControl(el, options.id);
 
-  const control = new PaintControl(el.widgetInstance, options);
+  const control = new PaintControl(el, options);
 
   el.mapInstance.addControl(control, options.position);
 }
 
-function removePaintControl(widgetInstance, controlId) {
+function removePaintControl(el, controlId) {
+  const widgetInstance = el.widgetInstance;
   const map = widgetInstance.getMap();
 
   const trackedControls = widgetInstance.getControls() || [];
@@ -222,7 +226,7 @@ function addPaintControlListeners() {
 
   Shiny.addCustomMessageHandler('removePaintControl', function (message) {
     withMapInstance(message.id, function (el) {
-      removePaintControl(el.widgetInstance, message.controlId);
+      removePaintControl(el, message.controlId);
     });
   });
 }


### PR DESCRIPTION
You can provide `orderKey` and `orderDirection` to `clusterOptions` to sort the spiderfied points from a cluster.
